### PR TITLE
Fix requestPermission on Android 13+

### DIFF
--- a/src/android/Serial.java
+++ b/src/android/Serial.java
@@ -207,8 +207,12 @@ public class Serial extends CordovaPlugin {
 					IntentFilter filter = new IntentFilter();
 					filter.addAction(UsbBroadcastReceiver.USB_PERMISSION);
 					// this broadcast receiver will handle the permission results
-					UsbBroadcastReceiver usbReceiver = new UsbBroadcastReceiver(callbackContext, cordova.getActivity());
-					cordova.getActivity().registerReceiver(usbReceiver, filter);
+                                        UsbBroadcastReceiver usbReceiver = new UsbBroadcastReceiver(callbackContext, cordova.getActivity());
+                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                            cordova.getActivity().registerReceiver(usbReceiver, filter, null, null, Context.RECEIVER_EXPORTED);
+                                        } else {
+                                            cordova.getActivity().registerReceiver(usbReceiver, filter);
+                                        }
 					// finally ask for the permission
 					manager.requestPermission(device, pendingIntent);
 				}


### PR DESCRIPTION
## Summary
- avoid crash when registering broadcast receiver on modern Android

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6858d8cc09f8832fa66b830f49fd4598